### PR TITLE
removed facebook logo to avoid getting jailed thanks to russian laws

### DIFF
--- a/voidform/templates/base.html
+++ b/voidform/templates/base.html
@@ -45,7 +45,6 @@
     <div class="socicons icon-menu">
 		<span class="socials">
 			<span class="section-title">follow us</span>
-			<a href="https://www.facebook.com/voidform.band" ><span class="socicon-facebook"></span></a>
 			<a href="https://vk.com/voidform" ><span class="socicon-vkontakte"></span></a>
 			<a href="https://www.youtube.com/channel/UC9naXJEF5rjfWtKZs1RxZaQ" ><span class="socicon-youtube"></span></a>
 			<a href="https://soundcloud.com/voidform" ><span class="socicon-soundcloud"></span></a>


### PR DESCRIPTION
So, Russia officially concluded that Meta is an extremist organization so technically displaying related logos (including facebook) can be considered a crime. 

Yes, I'm removing facebook's logo from music band site to not get jailed. 

FML.